### PR TITLE
Add Dockerfile with Python 3.10 and GDAL 3.6.2

### DIFF
--- a/Dockerfile.python.gdal
+++ b/Dockerfile.python.gdal
@@ -37,6 +37,6 @@ RUN pip install GDAL==$GDAL_VERSION
 
 # FROM python:3.10.5-slim-bullseye
 
-# COPY --from=python-base /src/shared_object_to_copy /usr/lib/x86_64-linux-gnu/
+# COPY --from=/usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/
 # COPY --from=python-base /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
 # COPY --from=python-base /usr/bin/gdal* /usr/bin/

--- a/Dockerfile.python.gdal
+++ b/Dockerfile.python.gdal
@@ -31,7 +31,7 @@ RUN cd gdal-$GDAL_VERSION \
     && cmake --build . --target install \
     && ls -1 -d /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/* > /tmp/post-install-gdal-so.log
 
-RUN pip install GDAL==3.6.2
+RUN pip install GDAL==$GDAL_VERSION
 
 ## Example to the next build stage:
 

--- a/Dockerfile.python.gdal
+++ b/Dockerfile.python.gdal
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.0.0-experimental
+
+FROM python:3.10.9-slim-bullseye AS python-base
+RUN  apt-get update && apt-get install -y \
+    build-essential \
+    wget \
+    cmake 
+
+RUN ls -1 -d /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/* > /tmp/pre-install-gdal-so.log \ 
+    && apt-get install -y libproj-dev \
+    libgeos-dev \
+    libgeotiff-dev \
+    libtiff-dev \
+    libcurl4-gnutls-dev \
+    libdeflate-dev \
+    python3 python3-dev python3-pip python3-setuptools python3-numpy
+
+
+WORKDIR /src
+
+ARG GDAL_VERSION=3.6.2
+
+# Instal GDAL 3.6.2
+RUN wget https://github.com/OSGeo/gdal/releases/download/v$GDAL_VERSION/gdal-$GDAL_VERSION.tar.gz && tar xzf gdal-$GDAL_VERSION.tar.gz && rm gdal-$GDAL_VERSION.tar.gz
+
+RUN cd gdal-$GDAL_VERSION \
+    && mkdir build \
+    && cd build \
+    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr \
+    && cmake --build . \
+    && cmake --build . --target install \
+    && ls -1 -d /usr/lib/x86_64-linux-gnu/ /usr/lib/x86_64-linux-gnu/* > /tmp/post-install-gdal-so.log
+
+RUN pip install GDAL==3.6.2
+
+## Example to the next build stage:
+
+# FROM python:3.10.5-slim-bullseye
+
+# COPY --from=python-base /src/shared_object_to_copy /usr/lib/x86_64-linux-gnu/
+# COPY --from=python-base /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+# COPY --from=python-base /usr/bin/gdal* /usr/bin/


### PR DESCRIPTION
This new Docker image is based on the latest official Python image and includes GDAL 3.6.2 built from source. 
This makes it possible to use the latest version of GDAL (at the moment), even in the `python:3.10.9-slim-bullseye` image, where the default version is `3.2.2` and version `3.6.2` is not available through `apt-get`.